### PR TITLE
Unrecognized even tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The tool supports single or multiple inscriptions in all input of the transactio
 
 # Installation
 ```
-go get https://github.com/balletcrypto/bitcoin-inscription-parser
+go get github.com/balletcrypto/bitcoin-inscription-parser
 ```
 # Example
 ```go

--- a/parser/script_parser.go
+++ b/parser/script_parser.go
@@ -20,9 +20,10 @@ type TransactionInscription struct {
 }
 
 type InscriptionContent struct {
-	ContentType   string
-	ContentBody   []byte
-	ContentLength uint64
+	ContentType             string
+	ContentBody             []byte
+	ContentLength           uint64
+	IsUnrecognizedEvenField bool
 }
 
 func ParseInscriptionsFromTransaction(msgTx *wire.MsgTx) []*TransactionInscription {
@@ -100,10 +101,11 @@ func ParseInscriptions(witnessScript []byte) []*InscriptionContent {
 
 func parseOneInscription(tokenizer *txscript.ScriptTokenizer) *InscriptionContent {
 	var (
-		tags          = make(map[string][]byte)
-		contentType   string
-		contentBody   []byte
-		contentLength uint64
+		tags                    = make(map[string][]byte)
+		contentType             string
+		contentBody             []byte
+		contentLength           uint64
+		isUnrecognizedEvenField bool
 	)
 
 	// Find any pushed data in the script. This includes OP_0, but not OP_1 - OP_16.
@@ -171,14 +173,16 @@ func parseOneInscription(tokenizer *txscript.ScriptTokenizer) *InscriptionConten
 		// Unrecognized even tag
 		tag, _ := hex.DecodeString(key)
 		if len(tag) > 0 && int(tag[0])%2 == 0 {
-			return nil
+			isUnrecognizedEvenField = true
+			continue
 		}
 	}
 
 	inscription := &InscriptionContent{
-		ContentType:   contentType,
-		ContentBody:   contentBody,
-		ContentLength: contentLength,
+		ContentType:             contentType,
+		ContentBody:             contentBody,
+		ContentLength:           contentLength,
+		IsUnrecognizedEvenField: isUnrecognizedEvenField,
 	}
 	return inscription
 }

--- a/tests/script_parser_test.go
+++ b/tests/script_parser_test.go
@@ -327,7 +327,7 @@ func TestScriptWithUnrecognizedEvenTag(t *testing.T) {
 	}{
 		testCase: "test script with unrecognized even tag",
 		script:   script,
-		expected: false,
+		expected: true,
 	}
 
 	inscriptions := parser.ParseInscriptions(test.script)


### PR DESCRIPTION
Unrecognized even tags are unbound and assigned negative inscription numbers