### PR TITLE
Filter inscriptions with invalid data length

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,36 +110,46 @@ PASS
 --- PASS: TestScriptWithUnrecognizedEvenTag (0.00s)
 PASS
 
+=== RUN   TestScriptWithNoContentTypeTag
+    script_parser_test.go:369: Find inscription with content type: , content length: 36
+    script_parser_test.go:375: test script with no content type tag: test passed
+--- PASS: TestScriptWithNoContentTypeTag (0.00s)
+PASS
+
 === RUN   TestScriptWithNoContentType
-    script_parser_test.go:369: Find inscription with content type: , content length: 32
-    script_parser_test.go:375: test script with no content type: test passed
+    script_parser_test.go:405: Find inscription with content type: , content length: 32
+    script_parser_test.go:411: test script with no content type: test passed
 --- PASS: TestScriptWithNoContentType (0.00s)
 PASS
 
 === RUN   TestScriptWithNoContentBody
-    script_parser_test.go:403: Find inscription with content type: text/plain;charset=utf-8, content length: 0
-    script_parser_test.go:409: test script with no content body: test passed
+    script_parser_test.go:439: Find inscription with content type: text/plain;charset=utf-8, content length: 0
+    script_parser_test.go:445: test script with no content body: test passed
 --- PASS: TestScriptWithNoContentBody (0.00s)
 PASS
 
+=== RUN   TestScriptWithInvalidDtaLength
+    script_parser_test.go:483: test script with invalid data length: test passed
+--- PASS: TestScriptWithInvalidDtaLength (0.00s)
+PASS
+
 === RUN   TestScriptWithZeroPush
-    script_parser_test.go:438: Find inscription with content type: text/plain;charset=utf-8, content length: 0
-    script_parser_test.go:444: test script with zero push: test passed
+    script_parser_test.go:512: Find inscription with content type: text/plain;charset=utf-8, content length: 0
+    script_parser_test.go:518: test script with zero push: test passed
 --- PASS: TestScriptWithZeroPush (0.00s)
 PASS
 
 === RUN   TestScriptWithMultiplePushes
-    script_parser_test.go:475: Find inscription with content type: text/plain;charset=utf-8, content length: 66
-    script_parser_test.go:481: test script with multiple pushes: test passed
+    script_parser_test.go:549: Find inscription with content type: text/plain;charset=utf-8, content length: 66
+    script_parser_test.go:555: test script with multiple pushes: test passed
 --- PASS: TestScriptWithMultiplePushes (0.00s)
 PASS
 
 === RUN   TestScriptWithNoEndIf
 === PAUSE TestScriptWithNoEndIf
 === CONT  TestScriptWithNoEndIf
-    script_parser_test.go:535: test script with no END_IF: test passed
-    script_parser_test.go:535: test script with no END_IF: test passed
+    script_parser_test.go:609: test script with no END_IF: test passed
+    script_parser_test.go:609: test script with no END_IF: test passed
 --- PASS: TestScriptWithNoEndIf (0.00s)
 PASS
-ok      command-line-arguments  0.173s
 ```

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ PASS
 PASS
 
 === RUN   TestScriptWithUnrecognizedEvenTag
+    script_parser_test.go:336: Find inscription with content type: text/plain;charset=utf-8, content length: 38
     script_parser_test.go:342: test script with unrecognized even tag: test passed
 --- PASS: TestScriptWithUnrecognizedEvenTag (0.00s)
 PASS

--- a/parser/script_parser.go
+++ b/parser/script_parser.go
@@ -143,7 +143,8 @@ func parseOneInscription(tokenizer *txscript.ScriptTokenizer) *InscriptionConten
 				return nil
 			}
 			if tokenizer.Next() {
-				if tokenizer.Data() == nil {
+				if tokenizer.Opcode() != txscript.OP_0 && tokenizer.Data() == nil {
+					// Invalid data length, e.g., 0b71bd09c848be66334c0cdaa32686e98dffa8a212af694f59165cdbb588e587
 					return nil
 				}
 				tags[tag] = tokenizer.Data()

--- a/parser/script_parser.go
+++ b/parser/script_parser.go
@@ -143,6 +143,9 @@ func parseOneInscription(tokenizer *txscript.ScriptTokenizer) *InscriptionConten
 				return nil
 			}
 			if tokenizer.Next() {
+				if tokenizer.Data() == nil {
+					return nil
+				}
 				tags[tag] = tokenizer.Data()
 			}
 		}

--- a/tests/script_parser_test.go
+++ b/tests/script_parser_test.go
@@ -126,7 +126,7 @@ func TestScriptWithMultipleInscriptions(t *testing.T) {
 	if expected == test.expected {
 		t.Logf("%s: test passed", test.testCase)
 	} else {
-		t.Errorf("%s: test passed", test.testCase)
+		t.Errorf("%s: test failed", test.testCase)
 	}
 }
 
@@ -303,7 +303,7 @@ func TestScriptWithOtherOpcodeBeforeEndIf(t *testing.T) {
 	if exist == test.expected {
 		t.Logf("%s: test passed", test.testCase)
 	} else {
-		t.Errorf("%s: test passed", test.testCase)
+		t.Errorf("%s: test failed", test.testCase)
 	}
 }
 
@@ -341,7 +341,40 @@ func TestScriptWithUnrecognizedEvenTag(t *testing.T) {
 	if exist == test.expected {
 		t.Logf("%s: test passed", test.testCase)
 	} else {
-		t.Errorf("%s: test passed", test.testCase)
+		t.Errorf("%s: test failed", test.testCase)
+	}
+}
+
+func TestScriptWithNoContentTypeTag(t *testing.T) {
+	script, _ := txscript.NewScriptBuilder().
+		AddOps([]byte{txscript.OP_FALSE, txscript.OP_IF}).
+		AddData([]byte("ord")).
+		AddOp(txscript.OP_0).
+		AddData([]byte("test script with no content type tag")).
+		AddOp(txscript.OP_ENDIF).Script()
+
+	test := struct {
+		testCase string
+		script   []byte
+		expected bool
+	}{
+		testCase: "test script with no content type tag",
+		script:   script,
+		expected: true,
+	}
+
+	inscriptions := parser.ParseInscriptions(test.script)
+	if len(inscriptions) != 0 {
+		for i := range inscriptions {
+			t.Logf("Find inscription with content type: %s, content length: %d", inscriptions[i].ContentType,
+				inscriptions[i].ContentLength)
+		}
+	}
+	exist := len(inscriptions) != 0
+	if exist == test.expected {
+		t.Logf("%s: test passed", test.testCase)
+	} else {
+		t.Errorf("%s: test failed", test.testCase)
 	}
 }
 
@@ -349,6 +382,9 @@ func TestScriptWithNoContentType(t *testing.T) {
 	script, _ := txscript.NewScriptBuilder().
 		AddOps([]byte{txscript.OP_FALSE, txscript.OP_IF}).
 		AddData([]byte("ord")).
+		AddOp(txscript.OP_DATA_1).
+		AddOp(txscript.OP_DATA_1).
+		AddOp(txscript.OP_0).
 		AddOp(txscript.OP_0).
 		AddData([]byte("test script with no content type")).
 		AddOp(txscript.OP_ENDIF).Script()
@@ -374,7 +410,7 @@ func TestScriptWithNoContentType(t *testing.T) {
 	if exist == test.expected {
 		t.Logf("%s: test passed", test.testCase)
 	} else {
-		t.Errorf("%s: test passed", test.testCase)
+		t.Errorf("%s: test failed", test.testCase)
 	}
 }
 
@@ -408,7 +444,45 @@ func TestScriptWithNoContentBody(t *testing.T) {
 	if exist == test.expected {
 		t.Logf("%s: test passed", test.testCase)
 	} else {
-		t.Errorf("%s: test passed", test.testCase)
+		t.Errorf("%s: test failed", test.testCase)
+	}
+}
+
+func TestScriptWithInvalidDtaLength(t *testing.T) {
+	script, _ := txscript.NewScriptBuilder().
+		AddOps([]byte{txscript.OP_FALSE, txscript.OP_IF}).
+		AddData([]byte("ord")).
+		AddOp(txscript.OP_DATA_1).
+		AddOp(txscript.OP_DATA_1).
+		AddData([]byte("text/plain;charset=utf-8")).
+		AddOp(txscript.OP_DATA_1).
+		AddOp(txscript.OP_DATA_66).
+		AddOp(txscript.OP_0).
+		AddData([]byte{0x62, 0x6f, 0x62, 0x2e, 0x73, 0x61, 0x74, 0x73, 0x0a}).
+		AddOp(txscript.OP_ENDIF).Script()
+
+	test := struct {
+		testCase string
+		script   []byte
+		expected bool
+	}{
+		testCase: "test script with invalid data length",
+		script:   script,
+		expected: false,
+	}
+
+	inscriptions := parser.ParseInscriptions(test.script)
+	if len(inscriptions) != 0 {
+		for i := range inscriptions {
+			t.Logf("Find inscription with content type: %s, content length: %d", inscriptions[i].ContentType,
+				inscriptions[i].ContentLength)
+		}
+	}
+	exist := len(inscriptions) != 0
+	if exist == test.expected {
+		t.Logf("%s: test passed", test.testCase)
+	} else {
+		t.Errorf("%s: test failed", test.testCase)
 	}
 }
 
@@ -443,7 +517,7 @@ func TestScriptWithZeroPush(t *testing.T) {
 	if exist == test.expected {
 		t.Logf("%s: test passed", test.testCase)
 	} else {
-		t.Errorf("%s: test passed", test.testCase)
+		t.Errorf("%s: test failed", test.testCase)
 	}
 }
 
@@ -480,7 +554,7 @@ func TestScriptWithMultiplePushes(t *testing.T) {
 	if exist == test.expected {
 		t.Logf("%s: test passed", test.testCase)
 	} else {
-		t.Errorf("%s: test passed", test.testCase)
+		t.Errorf("%s: test failed", test.testCase)
 	}
 }
 


### PR DESCRIPTION
There is an issue with invalid data length in some transaction input witness scripts, e.g., 0b71bd09c848be66334c0cdaa32686e98dffa8a212af694f59165cdbb588e587.