### PR TITLE
fix unrecognized even tag zero after OP_PUSHBYTES_1

### DIFF
--- a/parser/script_parser.go
+++ b/parser/script_parser.go
@@ -132,7 +132,8 @@ func parseOneInscription(tokenizer *txscript.ScriptTokenizer) *InscriptionConten
 					return nil
 				}
 			}
-			tags[BodyTag] = body
+			contentBody = body
+			contentLength = uint64(len(body))
 			break
 		} else {
 			if tokenizer.Data() == nil {
@@ -169,16 +170,10 @@ func parseOneInscription(tokenizer *txscript.ScriptTokenizer) *InscriptionConten
 			contentType = string(tags[ContentTypeTag])
 			continue
 		}
-		if key == BodyTag {
-			contentBody = tags[BodyTag]
-			contentLength = uint64(len(contentBody))
-			continue
-		}
 		// Unrecognized even tag
 		tag, _ := hex.DecodeString(key)
 		if len(tag) > 0 && int(tag[0])%2 == 0 {
 			isUnrecognizedEvenField = true
-			continue
 		}
 	}
 


### PR DESCRIPTION
fix unrecognized even tag zero after OP_PUSHBYTES_1, e.g., 96b6d7f6e1086d1125e7b9dc7375725952ab78dba34f12734b1feb84bdf87f55 and P2TR tapscript as follows:

P2TR tapscript: 
OP_0
OP_IF
OP_PUSHBYTES_3 
6f7264
OP_PUSHBYTES_1 01
OP_PUSHBYTES_24 
746578742f706c61696e3b636861727365743d7574662d38
OP_PUSHBYTES_1 00
OP_PUSHBYTES_12 54616b65727520416d616e6f
OP_ENDIF
OP_PUSHBYTES_32 67779831dbb597279c709b870c4ac8691ff4bc5bb1289417d66e311e1ea1d930
OP_CHECKSIG

